### PR TITLE
feat: add tiled exact search primitives and optional GPU scoring support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,15 @@ requires-python = "==3.11.*"
 readme = "README.md"
 license = {text = "MIT"}
 
+[project.optional-dependencies]
+gpu = [
+    "cupy-cuda12x>=13.3",
+]
 
 [tool.pdm]
 distribution = false
 
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 dev = [
     "cdr-bench @ file:///${PROJECT_ROOT}/",
     "jupyterlab>=4.2.5",

--- a/src/cdr_bench/optimization/__init__.py
+++ b/src/cdr_bench/optimization/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+_PARAM_EXPORTS = {
+    "ScoringParams",
+    "OptimizerParams",
+    "DimReducerParams",
+    "PCAParams",
+    "UMAPParams",
+    "TSNEParams",
+    "GTMParams",
+}
+
+_OPT_EXPORTS = {
+    "Optimizer",
+    "perform_optimization",
+    "create_param_grid",
+}
+
+__all__ = sorted(_PARAM_EXPORTS | _OPT_EXPORTS)
+
+
+def __getattr__(name: str):
+    if name in _PARAM_EXPORTS:
+        module = import_module(".params", __name__)
+        return getattr(module, name)
+    if name in _OPT_EXPORTS:
+        module = import_module(".optimization", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/cdr_bench/scoring/__init__.py
+++ b/src/cdr_bench/scoring/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+_SCORING_EXPORTS = {
+    "euclidean_distance_square_numba",
+    "tanimoto_int_similarity_matrix_numba",
+    "tanimoto_vector_similarity_numba",
+    "tanimoto_int_similarity_matrix",
+    "calculate_distance_matrix",
+    "calculate_distance_2_matrices",
+    "calculate_distances",
+    "get_ranks",
+    "coranking_matrix",
+    "coranking_measures",
+    "calculate_trustworthiness",
+    "calculate_continuity",
+    "calculate_metrics",
+    "correlate_distances",
+    "residual_variance",
+    "fit_nearest_neighbors",
+    "prepare_nearest_neighbors",
+    "calculate_nn_overlap_list",
+    "count_neighbors_with_high_similarity",
+    "indices_of_neighbors_with_high_similarity",
+    "plot_preservation_metrics",
+    "DRScorer",
+}
+
+__all__ = sorted(_SCORING_EXPORTS)
+
+
+def __getattr__(name: str):
+    if name in _SCORING_EXPORTS:
+        module = import_module(".scoring", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/cdr_bench/scoring/__init__.py
+++ b/src/cdr_bench/scoring/__init__.py
@@ -27,11 +27,24 @@ _SCORING_EXPORTS = {
     "DRScorer",
 }
 
-__all__ = sorted(_SCORING_EXPORTS)
+_TILED_EXPORTS = {
+    "compute_fp_squared_norms",
+    "exact_tanimoto_topk_from_block",
+    "resolve_tanimoto_backend",
+    "streaming_exact_topk",
+    "tanimoto_similarity_matrix_batch",
+    "topk_1d",
+    "topk_matrix",
+}
+
+__all__ = sorted(_SCORING_EXPORTS | _TILED_EXPORTS)
 
 
 def __getattr__(name: str):
     if name in _SCORING_EXPORTS:
         module = import_module(".scoring", __name__)
+        return getattr(module, name)
+    if name in _TILED_EXPORTS:
+        module = import_module(".scoring_tiled", __name__)
         return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/cdr_bench/scoring/gpu_kernels.py
+++ b/src/cdr_bench/scoring/gpu_kernels.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.util import find_spec
+
+import numpy as np
+
+_cp = None
+_cupy_error: Exception | None = None
+
+if find_spec("cupy") is not None:
+    try:
+        import cupy as _cp  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - optional dependency at runtime
+        _cp = None
+        _cupy_error = exc
+
+
+def has_gpu_support() -> bool:
+    """Return True when the optional CuPy dependency is importable."""
+    return _cp is not None
+
+
+def require_cupy():
+    """Return CuPy or raise a clear runtime error when the gpu extra is absent."""
+    if _cp is None:
+        raise RuntimeError(
+            "GPU scoring requires the optional 'gpu' extra. "
+            "Install it with: uv sync --extra gpu"
+        ) from _cupy_error
+    return _cp
+
+
+@dataclass(frozen=True)
+class CuPyQueryHandle:
+    """Prepared query tensors for one streamed search request."""
+
+    query_fp: object
+    query_sq: object
+    k: int
+
+
+class CuPyKernelBridge:
+    """CuPy-based kernel bridge skeleton for the streaming GPU path."""
+
+    BLOCK_THREADS = 128
+    MAX_KERNEL_TOPK = 32
+    KERNEL_TEMPLATE = r"""
+    #define BLOCK_THREADS %(block_threads)d
+    #define MAX_TOPK %(max_topk)d
+
+    extern "C" __device__ inline void insert_topk(
+        float score,
+        int row_id,
+        float* scores,
+        int* ids,
+        int k
+    ) {
+        if (k <= 0) {
+            return;
+        }
+        if (score <= scores[0]) {
+            return;
+        }
+        scores[0] = score;
+        ids[0] = row_id;
+        int pos = 0;
+        while (pos + 1 < k && scores[pos] > scores[pos + 1]) {
+            float score_tmp = scores[pos];
+            scores[pos] = scores[pos + 1];
+            scores[pos + 1] = score_tmp;
+            int id_tmp = ids[pos];
+            ids[pos] = ids[pos + 1];
+            ids[pos + 1] = id_tmp;
+            ++pos;
+        }
+    }
+
+    extern "C" __global__ void fused_tanimoto_topk_kernel(
+        const float* fps,
+        const float* fps_sq,
+        const float* query,
+        float query_sq,
+        int n_rows,
+        int fp_dim,
+        int k,
+        float* out_scores,
+        int* out_ids
+    ) {
+        const int tid = threadIdx.x;
+        __shared__ float shared_scores[BLOCK_THREADS * MAX_TOPK];
+        __shared__ int shared_ids[BLOCK_THREADS * MAX_TOPK];
+        __shared__ float block_scores[MAX_TOPK];
+        __shared__ int block_ids[MAX_TOPK];
+
+        float local_scores[MAX_TOPK];
+        int local_ids[MAX_TOPK];
+        for (int i = 0; i < MAX_TOPK; ++i) {
+            local_scores[i] = -3.402823e38f;
+            local_ids[i] = -1;
+        }
+
+        for (int row = tid; row < n_rows; row += BLOCK_THREADS) {
+            const float* cand = fps + ((size_t)row * (size_t)fp_dim);
+            float dot = 0.0f;
+            for (int d = 0; d < fp_dim; ++d) {
+                dot += cand[d] * query[d];
+            }
+            float denom = query_sq + fps_sq[row] - dot;
+            if (denom <= 0.0f) {
+                denom = 1.0f;
+            }
+            float sim = dot / denom;
+            insert_topk(sim, row, local_scores, local_ids, k);
+        }
+
+        const int base = tid * MAX_TOPK;
+        for (int i = 0; i < MAX_TOPK; ++i) {
+            shared_scores[base + i] = local_scores[i];
+            shared_ids[base + i] = local_ids[i];
+        }
+        __syncthreads();
+
+        if (tid == 0) {
+            for (int i = 0; i < MAX_TOPK; ++i) {
+                block_scores[i] = -3.402823e38f;
+                block_ids[i] = -1;
+            }
+            for (int t = 0; t < BLOCK_THREADS; ++t) {
+                const int off = t * MAX_TOPK;
+                for (int j = 0; j < k; ++j) {
+                    int row_id = shared_ids[off + j];
+                    if (row_id >= 0) {
+                        insert_topk(shared_scores[off + j], row_id, block_scores, block_ids, k);
+                    }
+                }
+            }
+            for (int i = 0; i < k; ++i) {
+                out_scores[i] = block_scores[k - 1 - i];
+                out_ids[i] = block_ids[k - 1 - i];
+            }
+        }
+    }
+    """
+
+    def __init__(self, *, rerank_factor: int = 4) -> None:
+        self.cp = require_cupy()
+        self.rerank_factor = max(1, int(rerank_factor))
+        self._module = self.cp.RawModule(
+            code=self.KERNEL_TEMPLATE
+            % {
+                "block_threads": self.BLOCK_THREADS,
+                "max_topk": self.MAX_KERNEL_TOPK,
+            },
+            options=("--std=c++11",),
+            name_expressions=("fused_tanimoto_topk_kernel",),
+        )
+        self._fused_kernel = self._module.get_function("fused_tanimoto_topk_kernel")
+
+    def prepare_query(self, query_fp: np.ndarray, k: int) -> CuPyQueryHandle:
+        """Upload one query to the device and precompute its squared norm."""
+        cp = self.cp
+        query_dev = cp.asarray(np.ascontiguousarray(query_fp, dtype=np.float32))
+        query_sq = cp.sum(query_dev * query_dev, dtype=cp.float32)
+        return CuPyQueryHandle(query_fp=query_dev, query_sq=query_sq, k=max(1, int(k)))
+
+    def enqueue_tile(
+        self,
+        slot: object,
+        *,
+        query_handle: CuPyQueryHandle,
+        tile_rows: int,
+        rerank_width: int,
+    ) -> None:
+        """Schedule H2D copy, CuPy scoring, and tiny D2H top-k export for one tile."""
+        cp = self.cp
+        local_k = min(max(1, int(rerank_width)), tile_rows)
+        slot.local_topk = local_k
+
+        with slot.copy_stream:
+            slot.dev_fp[:tile_rows].set(slot.host_fp[:tile_rows], stream=slot.copy_stream)
+            if slot.dev_sq is not None and slot.host_sq is not None:
+                slot.dev_sq[:tile_rows].set(slot.host_sq[:tile_rows], stream=slot.copy_stream)
+            slot.copy_done.record(slot.copy_stream)
+
+        with slot.compute_stream:
+            slot.compute_stream.wait_event(slot.copy_done)
+            if local_k <= self.MAX_KERNEL_TOPK:
+                self._fused_kernel(
+                    (1,),
+                    (self.BLOCK_THREADS,),
+                    (
+                        slot.dev_fp,
+                        slot.dev_sq,
+                        query_handle.query_fp,
+                        np.float32(query_handle.query_sq.item()),
+                        np.int32(tile_rows),
+                        np.int32(query_handle.query_fp.shape[0]),
+                        np.int32(local_k),
+                        slot.dev_topk_scores,
+                        slot.dev_topk_ids,
+                    ),
+                )
+            else:
+                self._enqueue_tile_fallback(
+                    slot,
+                    query_handle=query_handle,
+                    tile_rows=tile_rows,
+                    local_k=local_k,
+                )
+            slot.compute_done.record(slot.compute_stream)
+
+            cp.asnumpy(slot.dev_topk_ids[:local_k], out=slot.host_topk_ids[:local_k], stream=slot.compute_stream)
+            cp.asnumpy(slot.dev_topk_scores[:local_k], out=slot.host_topk_scores[:local_k], stream=slot.compute_stream)
+            slot.d2h_done.record(slot.compute_stream)
+
+    def _enqueue_tile_fallback(
+        self,
+        slot: object,
+        *,
+        query_handle: CuPyQueryHandle,
+        tile_rows: int,
+        local_k: int,
+    ) -> None:
+        """Fallback CuPy path for rerank widths larger than the fused kernel supports."""
+        cp = self.cp
+        dev_fp = slot.dev_fp[:tile_rows]
+        if slot.dev_sq is not None:
+            dev_sq = slot.dev_sq[:tile_rows]
+        else:
+            dev_sq = cp.sum(dev_fp * dev_fp, axis=1, dtype=cp.float32)
+
+        dot = dev_fp @ query_handle.query_fp
+        denom = cp.maximum(query_handle.query_sq + dev_sq - dot, cp.float32(1.0))
+        sims = dot / denom
+
+        top_idx = cp.argpartition(sims, -local_k)[-local_k:]
+        top_scores = sims[top_idx]
+        order = cp.argsort(top_scores)[::-1]
+        slot.dev_topk_ids[:local_k] = top_idx[order].astype(cp.int32)
+        slot.dev_topk_scores[:local_k] = top_scores[order].astype(cp.float32)
+
+    def is_slot_complete(self, slot: object) -> bool:
+        """Return True when D2H export for one tile-local top-k is finished."""
+        return bool(slot.d2h_done.done)
+
+    def collect_tile_topk(self, slot: object) -> tuple[np.ndarray, np.ndarray]:
+        """Map tile-local indices back to global row ids on the host."""
+        local_k = int(slot.local_topk)
+        local_ids = np.asarray(slot.host_topk_ids[:local_k], dtype=np.int32)
+        local_scores = np.asarray(slot.host_topk_scores[:local_k], dtype=np.float32)
+        row_ids = np.asarray(slot.row_ids[local_ids], dtype=np.int32)
+        return row_ids, local_scores

--- a/src/cdr_bench/scoring/scoring_tiled.py
+++ b/src/cdr_bench/scoring/scoring_tiled.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import heapq
+import logging
+from typing import Callable
+
+import numpy as np
+from numba import njit, prange
+
+try:
+    import torch
+except Exception:  # pragma: no cover - optional dependency at runtime
+    torch = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+@njit(parallel=True, fastmath=True)
+def tanimoto_similarity_matrix_numba(v_a: np.ndarray, v_b: np.ndarray) -> np.ndarray:
+    """Numba-accelerated generalized Tanimoto similarity for dense matrices."""
+    num_rows_a = v_a.shape[0]
+    num_rows_b = v_b.shape[0]
+    similarity_matrix = np.empty((num_rows_a, num_rows_b), dtype=np.float32)
+
+    sum_a_squared = np.sum(np.square(v_a), axis=1)
+    sum_b_squared = np.sum(np.square(v_b), axis=1)
+
+    for i in prange(num_rows_a):
+        for j in prange(num_rows_b):
+            numerator = np.dot(v_a[i], v_b[j])
+            denominator = sum_a_squared[i] + sum_b_squared[j] - numerator
+            if denominator <= 0.0:
+                similarity_matrix[i, j] = 0.0
+            else:
+                similarity_matrix[i, j] = numerator / denominator
+
+    return similarity_matrix
+
+
+_DEFAULT_TANIMOTO_BACKEND = "cdr_bench_numba"
+
+
+def resolve_tanimoto_backend(backend: str | None) -> str:
+    """Resolve a backend name to a concrete implementation."""
+    name = (backend or "auto").lower()
+    if name == "auto":
+        return _DEFAULT_TANIMOTO_BACKEND
+    if name in {"cdr_bench", "cdr_bench_blas", "cdr_bench_numba", "cdr_bench_fused"}:
+        return _DEFAULT_TANIMOTO_BACKEND
+    if name in {"gpu", "torch", "torch_cuda"}:
+        if torch is None or not torch.cuda.is_available():
+            logger.warning(
+                "Requested backend '%s' but CUDA torch is unavailable; using numpy.",
+                backend,
+            )
+            return "numpy"
+        return "torch_cuda"
+    if name in {"numpy", "cpu"}:
+        return "numpy"
+    raise ValueError(f"Unknown Tanimoto backend: {backend!r}")
+
+
+def compute_fp_squared_norms(fps: np.ndarray) -> np.ndarray:
+    """Precompute ||fp_i||^2 for a fingerprint matrix."""
+    return np.einsum("ij,ij->i", fps, fps, dtype=np.float32).astype(np.float32)
+
+
+def topk_1d(
+    scores: np.ndarray,
+    rows: np.ndarray,
+    k: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return top-k rows and scores for a single similarity vector."""
+    effective_k = min(k, len(scores))
+    if effective_k <= 0:
+        return np.empty(0, dtype=np.int32), np.empty(0, dtype=np.float32)
+    if effective_k == len(scores):
+        order = np.argsort(scores)[::-1]
+        return rows[order].astype(np.int32), scores[order].astype(np.float32)
+    top_local = np.argpartition(scores, -effective_k)[-effective_k:]
+    top_local = top_local[np.argsort(scores[top_local])[::-1]]
+    return rows[top_local].astype(np.int32), scores[top_local].astype(np.float32)
+
+
+def topk_matrix(
+    scores: np.ndarray,
+    rows: np.ndarray,
+    k: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Vectorized top-k over rows of a similarity matrix."""
+    if scores.ndim != 2:
+        raise ValueError("scores must be a 2-D array")
+    n_rows, n_cols = scores.shape
+    effective_k = min(k, n_cols)
+    if effective_k <= 0:
+        return (
+            np.empty((n_rows, 0), dtype=np.int32),
+            np.empty((n_rows, 0), dtype=np.float32),
+        )
+    if effective_k == n_cols:
+        top_local = np.argsort(scores, axis=1)[:, ::-1]
+        top_scores = np.take_along_axis(scores, top_local, axis=1)
+    else:
+        top_local = np.argpartition(scores, -effective_k, axis=1)[:, -effective_k:]
+        top_scores = np.take_along_axis(scores, top_local, axis=1)
+        order = np.argsort(top_scores, axis=1)[:, ::-1]
+        top_local = np.take_along_axis(top_local, order, axis=1)
+        top_scores = np.take_along_axis(top_scores, order, axis=1)
+
+    if rows.ndim == 1:
+        top_rows = rows[top_local]
+    else:
+        top_rows = np.take_along_axis(rows, top_local, axis=1)
+    return top_rows.astype(np.int32), top_scores.astype(np.float32)
+
+
+def tanimoto_similarity_matrix_batch(
+    queries: np.ndarray,
+    candidates: np.ndarray,
+    *,
+    candidate_sq: np.ndarray | None = None,
+    query_sq: np.ndarray | None = None,
+    backend: str | None = None,
+) -> np.ndarray:
+    """Compute pairwise generalized Tanimoto between query and candidate blocks."""
+    resolved_backend = resolve_tanimoto_backend(backend)
+
+    if resolved_backend == "torch_cuda":
+        assert torch is not None  # guarded by resolve_tanimoto_backend
+        device = torch.device("cuda")
+        queries = np.ascontiguousarray(queries, dtype=np.float32)
+        candidates = np.ascontiguousarray(candidates, dtype=np.float32)
+        queries_t = torch.from_numpy(queries).to(device=device)
+        candidates_t = torch.from_numpy(candidates).to(device=device)
+        dot = queries_t @ candidates_t.T
+        if query_sq is None:
+            q_sq_t = (queries_t * queries_t).sum(dim=1, keepdim=True)
+        else:
+            q_sq_t = torch.from_numpy(
+                np.ascontiguousarray(query_sq, dtype=np.float32).reshape(-1, 1)
+            ).to(device=device)
+        if candidate_sq is None:
+            candidate_sq_t = (candidates_t * candidates_t).sum(dim=1)
+        else:
+            candidate_sq_t = torch.from_numpy(
+                np.ascontiguousarray(candidate_sq, dtype=np.float32)
+            ).to(device=device)
+        denom = torch.clamp(q_sq_t + candidate_sq_t - dot, min=1.0)
+        return (dot / denom).to(dtype=torch.float32, device="cpu").numpy()
+
+    if resolved_backend.startswith("cdr_bench"):
+        return tanimoto_similarity_matrix_numba(queries, candidates)
+
+    queries = np.ascontiguousarray(queries, dtype=np.float32)
+    candidates = np.ascontiguousarray(candidates, dtype=np.float32)
+    dot = queries @ candidates.T
+    if query_sq is None:
+        query_sq = (queries * queries).sum(axis=1, keepdims=False)
+    query_sq = np.ascontiguousarray(query_sq, dtype=np.float32).reshape(-1, 1)
+    if candidate_sq is None:
+        candidate_sq = (candidates * candidates).sum(axis=1, keepdims=False)
+    else:
+        candidate_sq = np.ascontiguousarray(candidate_sq, dtype=np.float32)
+    denom = np.where(query_sq + candidate_sq - dot > 0.0, query_sq + candidate_sq - dot, np.float32(1.0))
+    return (dot / denom).astype(np.float32)
+
+
+def exact_tanimoto_topk_from_block(
+    query_fp: np.ndarray,
+    cand_fps: np.ndarray,
+    candidate_rows: np.ndarray,
+    k: int,
+    *,
+    candidate_sq: np.ndarray | None = None,
+    backend: str | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Exact top-k against a preloaded candidate block."""
+    if len(candidate_rows) == 0:
+        return np.empty(0, dtype=np.int32), np.empty(0, dtype=np.float32)
+
+    query = np.ascontiguousarray(query_fp[np.newaxis, :], dtype=np.float32)
+    query_sq = np.asarray([float(np.dot(query[0], query[0]))], dtype=np.float32)
+    sims = tanimoto_similarity_matrix_batch(
+        query,
+        np.ascontiguousarray(cand_fps, dtype=np.float32),
+        query_sq=query_sq,
+        candidate_sq=candidate_sq,
+        backend=backend,
+    )[0]
+    return topk_1d(sims, candidate_rows, k)
+
+
+def streaming_exact_topk(
+    query_fp: np.ndarray,
+    candidate_rows: np.ndarray,
+    k: int,
+    *,
+    block_loader: Callable[[int, int], tuple[np.ndarray, np.ndarray, np.ndarray]],
+    tile_rows: int = 10_000,
+    log_every_tiles: int = 0,
+    log_label: str | None = None,
+    backend: str | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Stream exact top-k with O(N log K) merge cost."""
+    total_rows = len(candidate_rows)
+    effective_k = min(k, total_rows)
+    if effective_k <= 0:
+        return np.empty(0, dtype=np.int32), np.empty(0, dtype=np.float32)
+
+    tile_rows = max(1, int(tile_rows))
+    total_tiles = (total_rows + tile_rows - 1) // tile_rows
+    heap: list[tuple[float, int]] = []
+
+    for tile_idx, start in enumerate(range(0, total_rows, tile_rows), start=1):
+        end = min(start + tile_rows, total_rows)
+        rows_tile, fps_tile, sq_tile = block_loader(start, end)
+        sims_tile = tanimoto_similarity_matrix_batch(
+            np.ascontiguousarray(query_fp[np.newaxis, :], dtype=np.float32),
+            fps_tile,
+            query_sq=np.asarray([float(np.dot(query_fp, query_fp))], dtype=np.float32),
+            candidate_sq=sq_tile,
+            backend=backend,
+        )[0]
+        local_rows, local_scores = topk_1d(sims_tile, rows_tile, effective_k)
+        for row_id, score in zip(local_rows.tolist(), local_scores.tolist()):
+            entry = (float(score), int(row_id))
+            if len(heap) < effective_k:
+                heapq.heappush(heap, entry)
+            elif entry[0] > heap[0][0]:
+                heapq.heapreplace(heap, entry)
+
+        if log_every_tiles > 0 and (
+            tile_idx == 1 or tile_idx % log_every_tiles == 0 or tile_idx == total_tiles
+        ):
+            retained_floor = heap[0][0] if heap else float("nan")
+            label = f"{log_label}: " if log_label else ""
+            logger.info(
+                "%sstreaming exact top-k tile %d/%d rows=%d/%d retained_floor=%.4f",
+                label,
+                tile_idx,
+                total_tiles,
+                end,
+                total_rows,
+                retained_floor,
+            )
+
+    top_items = sorted(heap, reverse=True)
+    top_scores = np.asarray([score for score, _ in top_items], dtype=np.float32)
+    top_rows = np.asarray([row_id for _, row_id in top_items], dtype=np.int32)
+    return top_rows, top_scores


### PR DESCRIPTION
## Summary
- add lazy package exports for `scoring` and `optimization` to avoid eager import cycles
- add `scoring_tiled.py` with tiled exact-search utilities for squared norms, batched Tanimoto, and streamed top-k selection
- add an optional CuPy-based GPU kernel bridge plus a `gpu` extra so CPU-only installs continue to work unchanged

## Details
This PR prepares `cdr_bench` to act as a reusable compute backend for large-scale exact search workloads.

The CPU layer adds:
- `compute_fp_squared_norms`
- `tanimoto_similarity_matrix_batch`
- `topk_1d` / `topk_matrix`
- `exact_tanimoto_topk_from_block`
- `streaming_exact_topk`
- `resolve_tanimoto_backend`

The GPU layer adds:
- `gpu_kernels.py` with a safe CuPy import wrapper
- `CuPyKernelBridge` with a `RawModule` fused top-k kernel path and a CuPy fallback path
- optional dependency wiring under `[project.optional-dependencies].gpu`

## Validation
- compiled `scoring_tiled.py` and `gpu_kernels.py`
- import smoke for `from cdr_bench.scoring import compute_fp_squared_norms, streaming_exact_topk`
- verified the GPU guard path on a CPU environment returns `has_gpu_support() == False` instead of breaking imports

## Notes
The GPU bridge is intentionally optional and isolated. A CPU-only `uv sync` should continue to work without `cupy` installed, while GPU users can opt in with `uv sync --extra gpu`.